### PR TITLE
Fix error handling

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -131,11 +131,7 @@ export const managerApiRequest = <S, DispatchExt>(
       };
       dispatch(response);
     })
-    .catch(async (errorData: THideawayReason) => {
-      let reason: THideawayReason = errorData;
-      if (reason.constructor.name === 'Response') {
-        reason = await (errorData as Response).json().then((body) => body);
-      }
+    .catch(async (reason: THideawayReason) => {
       const actionContent: IHideawayActionContent<S, DispatchExt> = {
         type: `${type}_ERROR`,
         payload: (reason as unknown) as S,

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -298,7 +298,7 @@ describe('middleware -> core -> highaway', () => {
       await triggerAction(action, store);
       const result = _.last(store.dispatchList);
       expect(result?.type).toEqual(`${type}_ERROR`);
-      expect(result?.payload).toBe('');
+      expect(result?.payload).toBe(response);
     });
 
     it('shoud dispatch the action error in a response action', async () => {


### PR DESCRIPTION
Error response will be parsed by json on [this line](https://github.com/Ozahata/hideaway/blob/master/src/manager.ts#L137).
But error response may not return as json format, then it will be failed on some cases.

```
e.g. Timeout error (504), returns html
Uncaught (in promise) SyntaxError: Unexpected token < in JSON at position 0
```

I think should dispatch payload with response as is, then error handling should be done by app side (= `onErrorMiddleware`).